### PR TITLE
[35기 노정은]  Cart :  +,- 버튼 누르면 총 주문량 카운트되게 구현

### DIFF
--- a/public/data/cartData.json
+++ b/public/data/cartData.json
@@ -3,24 +3,28 @@
     "id" : 1,
     "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
     "title" : "PATAGONIA",
-    "price" : 16000
+    "price" : 16000,
+    "order" : 3
   },
   {
     "id" : 2,
     "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
     "title" : "LUSH",
-    "price" : 13000
+    "price" : 13000,
+    "order" : 2
   },
   {
     "id" : 3,
     "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
     "title" : "TOOLS",
-    "price" : 15000
+    "price" : 15000,
+    "order" : 4
   },
   {
     "id" : 4,
     "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
     "title" : "LEMAIRE",
-    "price" : 18000
+    "price" : 18000,
+    "order" : 1
   }
 ]

--- a/public/data/cartData.json
+++ b/public/data/cartData.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id" : 1,
+    "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "title" : "PATAGONIA",
+    "price" : 16000
+  },
+  {
+    "id" : 2,
+    "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "title" : "LUSH",
+    "price" : 13000
+  },
+  {
+    "id" : 3,
+    "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "title" : "TOOLS",
+    "price" : 15000
+  },
+  {
+    "id" : 4,
+    "cart_img_url" : "https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80",
+    "title" : "LEMAIRE",
+    "price" : 18000
+  }
+]

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,7 +1,50 @@
-import React from 'react';
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useState } from 'react';
+import './Cart.scss';
 
 const Cart = () => {
-  return <div />;
+  const [cartCount, setCartCount] = useState(0);
+
+  return (
+    <div className="cartModal">
+      <div className="cartNav">
+        <span>Cart[{cartCount}]</span>
+        <span>Close</span>
+      </div>
+      <div className="cartMain">
+        <div className="empty">
+          <p>장바구니가 비어 있습니다.</p>
+        </div>
+        {/* <div className="selected">
+          <div className="productInfo">
+            <img
+              src="https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80"
+              alt="selected_tiny"
+            />
+            <div className="description">
+              <div>LE LABO</div>
+              <div>₩15,000</div>
+              <div className="count">
+                <img
+                  src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
+                  alt="minus"
+                />
+                <span>4</span>
+                <img
+                  src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
+                  alt="plus"
+                />
+              </div>
+            </div>
+            <p className="delete">×</p>
+          </div>
+        </div> */}
+      </div>
+      {/* <a className="cartFooter">
+        <span>₩18,000 VIEW ALL</span>
+      </a> */}
+    </div>
+  );
 };
 
 export default Cart;

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -4,6 +4,11 @@ import './Cart.scss';
 const Cart = () => {
   const [orderQuantity, setOrderQuantity] = useState(0);
   const [cartData, setCartData] = useState([]);
+  const [cartModal, setCartModal] = useState(true);
+
+  const closeCart = () => {
+    setCartModal(false);
+  };
 
   useEffect(() => {
     fetch('data/cartData.json')
@@ -14,7 +19,11 @@ const Cart = () => {
   }, []);
 
   return (
-    <div className="cartModal">
+    <div
+      className="cartModal"
+      style={cartModal ? { visibility: 'visible' } : { visibility: 'hidden' }}
+      onClick={closeCart}
+    >
       <div className="cartNav">
         <span>Cart[{orderQuantity}]</span>
         <span>Close</span>
@@ -26,13 +35,7 @@ const Cart = () => {
 
         {/* 여기 map 돌리면 됨 */}
         {cartData.map(cartData => {
-          return (
-            <SelectedPrd
-              key={cartData.id}
-              setOrderQuantity={setOrderQuantity}
-              cartData={cartData}
-            />
-          );
+          return <SelectedPrd key={cartData.id} cartData={cartData} />;
         })}
       </div>
       <div className="cartFooter">
@@ -48,7 +51,7 @@ function SelectedPrd({ cartData }) {
 
   const [orderQuantity, setOrderQuantity] = useState(0);
 
-  const [cartModal, setCartModal] = useState(true);
+  const [selected, setSelected] = useState(true);
 
   const priceThousand = price.toString().slice(0, 2);
 
@@ -66,14 +69,14 @@ function SelectedPrd({ cartData }) {
 
   function deleteProduct() {
     alert('선택하신 상품을 삭제하시겠습니까?');
-    setCartModal(false);
+    setSelected(false);
   }
 
   return (
     <div
       key={id}
       className="selected"
-      style={cartModal ? { display: 'flex' } : { display: 'none' }}
+      style={selected ? { display: 'flex' } : { display: 'none' }}
     >
       <div className="productInfo">
         <img src={cart_img_url} alt="selected_tiny" />

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,9 +1,9 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from 'react';
+import React from 'react';
 import './Cart.scss';
 
 const Cart = () => {
-  const [cartCount, setCartCount] = useState(0);
+  // const [cartCount, setCartCount] = useState(0);
 
   return (
     <div className="cartModal">
@@ -12,10 +12,10 @@ const Cart = () => {
         <span>Close</span>
       </div>
       <div className="cartMain">
-        <div className="empty">
+        {/* <div className="empty">
           <p>장바구니가 비어 있습니다.</p>
-        </div>
-        {/* <div className="selected">
+        </div> */}
+        <div className="selected">
           <div className="productInfo">
             <img
               src="https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80"
@@ -38,11 +38,11 @@ const Cart = () => {
             </div>
             <p className="delete">×</p>
           </div>
-        </div> */}
+        </div>
       </div>
-      {/* <a className="cartFooter">
+      <a className="cartFooter">
         <span>₩18,000 VIEW ALL</span>
-      </a> */}
+      </a>
     </div>
   );
 };

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -23,6 +23,7 @@ const Cart = () => {
         {/* <div className="empty">
             <p>장바구니가 비어 있습니다.</p>
           </div> */}
+
         {/* 여기 map 돌리면 됨 */}
         {cartData.map(cartData => {
           return (
@@ -34,17 +35,22 @@ const Cart = () => {
           );
         })}
       </div>
-      <a className="cartFooter">
+      <div className="cartFooter">
         <span>
           ₩{orderQuantity === 0 ? 15 : 15 * orderQuantity},000 VIEW ALL
         </span>
-      </a>
+      </div>
     </div>
   );
 };
 function SelectedPrd({ cartData }) {
+  const { cart_img_url, id, price, title } = cartData;
+
   const [orderQuantity, setOrderQuantity] = useState(0);
+
   const [cartModal, setCartModal] = useState(true);
+
+  const priceThousand = price.toString().slice(0, 2);
 
   function minusOrderQuantity() {
     if (orderQuantity < 2) {
@@ -53,24 +59,27 @@ function SelectedPrd({ cartData }) {
       setOrderQuantity(orderQuantity - 1);
     }
   }
+
   function plusOrderQuantity() {
     setOrderQuantity(orderQuantity + 1);
   }
+
   function deleteProduct() {
     alert('선택하신 상품을 삭제하시겠습니까?');
     setCartModal(false);
   }
+
   return (
     <div
-      key={cartData.id}
+      key={id}
       className="selected"
       style={cartModal ? { display: 'flex' } : { display: 'none' }}
     >
       <div className="productInfo">
-        <img src={cartData.cart_img_url} alt="selected_tiny" />
+        <img src={cart_img_url} alt="selected_tiny" />
         <div className="description">
-          <div>{cartData.title}</div>
-          <div>₩{cartData.price},000</div>
+          <div>{title}</div>
+          <div>₩{priceThousand},000</div>
           <div className="count">
             <img
               onClick={minusOrderQuantity}

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -8,7 +8,7 @@ const Cart = () => {
   return (
     <div className="cartModal">
       <div className="cartNav">
-        <span>Cart[{cartCount}]</span>
+        <span>Cart[]</span>
         <span>Close</span>
       </div>
       <div className="cartMain">

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import SelectedPrd from './SelectedPrd';
 import './Cart.scss';
 
 const Cart = () => {
@@ -7,14 +8,7 @@ const Cart = () => {
   const [cartModal, setCartModal] = useState(true);
   const [total, setTotal] = useState(0);
 
-  // console.log(cartData);
-
-  const totalPrice = cartData[0]?.price.toString().slice(0, 2) * orderQuantity;
-  // console.log(totalPrice);
-
-  function changeTotal() {
-    setTotal(totalPrice);
-  }
+  // const totalPrice = cartData[0]?.price.toString().slice(0, 2) * orderQuantity;
 
   function getCartDataPrice(cartData) {
     let cartDataPrice = [];
@@ -25,12 +19,8 @@ const Cart = () => {
     }
     return cartDataPrice;
   }
-  const priceThousand = getCartDataPrice(cartData);
-  console.log(priceThousand && priceThousand?.reduce((a, b) => a + b));
-
-  // function totalPrice() {
-
-  // }
+  // const priceThousand = getCartDataPrice(cartData);
+  // console.log(priceThousand && priceThousand?.reduce((a, b) => a + b));
 
   const closeCart = () => {
     setCartModal(false);
@@ -77,7 +67,6 @@ const Cart = () => {
               cartData={cartData}
               minusOrderQuantity={minusOrderQuantity}
               plusOrderQuantity={plusOrderQuantity}
-              changeTotal={changeTotal}
             />
           );
         })}
@@ -91,78 +80,4 @@ const Cart = () => {
     </div>
   );
 };
-function SelectedPrd({
-  cartData,
-  minusOrderQuantity,
-  plusOrderQuantity,
-  changeTotal,
-}) {
-  const [orderQuantity, setOrderQuantity] = useState(1);
-  const totalPrice = cartData.price * orderQuantity;
-  // console.log(totalPrice);
-  // console.log(cartData);
-
-  const plus = () => {
-    setOrderQuantity(prev => prev + 1);
-    plusOrderQuantity();
-
-    const totalPrice = cartData.price * orderQuantity;
-    changeTotal(cartData.price * orderQuantity);
-    // console.log(totalPrice);
-  };
-
-  const minus = e => {
-    // console.log(e.target);
-    if (orderQuantity < 2) {
-      setOrderQuantity(1);
-    } else {
-      setOrderQuantity(prev => prev - 1);
-    }
-    minusOrderQuantity();
-    changeTotal(totalPrice);
-  };
-
-  const [selected, setSelected] = useState(true);
-
-  const priceThousand = cartData.price.toString().slice(0, 2);
-  // console.log(priceThousand);
-
-  function deleteProduct() {
-    alert('선택하신 상품을 삭제하시겠습니까?');
-    setSelected(false);
-  }
-
-  return (
-    <div
-      key={cartData.id}
-      className="selected"
-      style={selected ? { display: 'flex' } : { display: 'none' }}
-    >
-      <div className="productInfo">
-        <img src={cartData.cart_img_url} alt="selected_tiny" />
-        <div className="description">
-          <div>{cartData.title}</div>
-          <div>₩{priceThousand},000</div>
-          <div className="count">
-            <img
-              onClick={minus}
-              src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
-              alt="minus"
-            />
-            <span>{orderQuantity}</span>
-            <img
-              onClick={plus}
-              src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
-              alt="plus"
-            />
-          </div>
-        </div>
-        <p onClick={deleteProduct} className="delete">
-          ×
-        </p>
-      </div>
-    </div>
-  );
-}
-
 export default Cart;

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,85 +1,96 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 import React, { useState, useEffect } from 'react';
 import './Cart.scss';
 
 const Cart = () => {
-  //   const [orderQuantity, setOrderQuantity] = useState(0);
-  //   const [cartModal, setCartModal] = useState(true);
-  //   const [cartData, setCartData] = useState([]);
-  //   useEffect(() => {
-  //     fetch('data/cartData.json')
-  //       .then(res => res.json())
-  //       .then(data => {
-  //         setCartData(data);
-  //       });
-  //   }, []);
-  //   function minusOrderQuantity() {
-  //     if (orderQuantity < 2) {
-  //       setOrderQuantity(1);
-  //     } else {
-  //       setOrderQuantity(orderQuantity - 1);
-  //     }
-  //   }
-  //   function plusOrderQuantity() {
-  //     setOrderQuantity(orderQuantity + 1);
-  //   }
-  //   function deleteProduct() {
-  //     alert('선택하신 상품을 삭제하시겠습니까?');
-  //     setCartModal(false);
-  //   }
-  //   return (
-  //     <div className="cartModal">
-  //       <div className="cartNav">
-  //         <span>Cart[{orderQuantity}]</span>
-  //         <span>Close</span>
-  //       </div>
-  //       <div className="cartMain">
-  //         {/* <div className="empty">
-  //           <p>장바구니가 비어 있습니다.</p>
-  //         </div> */}
-  //         {/* 여기 map 돌리면 됨 */}
-  //         {cartData.map(cartData => {
-  //           return <SelectedPrd cartData={cartData} />;
-  //         })}
-  //       </div>
-  //       <a className="cartFooter">
-  //         <span>
-  //           ₩{orderQuantity === 0 ? 15 : 15 * orderQuantity},000 VIEW ALL
-  //         </span>
-  //       </a>
-  //     </div>
-  //   );
-  // };
-  // function SelectedPrd({ cartData }) {
-  //   <div
-  //     key={cartData.id}
-  //     className="selected"
-  //     style={cartModal ? { display: 'flex' } : { display: 'none' }}
-  //   >
-  //     <div className="productInfo">
-  //       <img src={cartData.cart_img_url} alt="selected_tiny" />
-  //       <div className="description">
-  //         <div>{cartData.title}</div>
-  //         <div>₩{cartData.price},000</div>
-  //         <div className="count">
-  //           <img
-  //             onClick={minusOrderQuantity}
-  //             src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
-  //             alt="minus"
-  //           />
-  //           <span>{orderQuantity}</span>
-  //           <img
-  //             onClick={plusOrderQuantity}
-  //             src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
-  //             alt="plus"
-  //           />
-  //         </div>
-  //       </div>
-  //       <p onClick={deleteProduct} className="delete">
-  //         ×
-  //       </p>
-  //     </div>
-  //   </div>;
+  const [orderQuantity, setOrderQuantity] = useState(0);
+  const [cartData, setCartData] = useState([]);
+
+  useEffect(() => {
+    fetch('data/cartData.json')
+      .then(res => res.json())
+      .then(data => {
+        setCartData(data);
+      });
+  }, []);
+
+  return (
+    <div className="cartModal">
+      <div className="cartNav">
+        <span>Cart[{orderQuantity}]</span>
+        <span>Close</span>
+      </div>
+      <div className="cartMain">
+        {/* <div className="empty">
+            <p>장바구니가 비어 있습니다.</p>
+          </div> */}
+        {/* 여기 map 돌리면 됨 */}
+        {cartData.map(cartData => {
+          return (
+            <SelectedPrd
+              key={cartData.id}
+              setOrderQuantity={setOrderQuantity}
+              cartData={cartData}
+            />
+          );
+        })}
+      </div>
+      <a className="cartFooter">
+        <span>
+          ₩{orderQuantity === 0 ? 15 : 15 * orderQuantity},000 VIEW ALL
+        </span>
+      </a>
+    </div>
+  );
 };
+function SelectedPrd({ cartData }) {
+  const [orderQuantity, setOrderQuantity] = useState(0);
+  const [cartModal, setCartModal] = useState(true);
+
+  function minusOrderQuantity() {
+    if (orderQuantity < 2) {
+      setOrderQuantity(1);
+    } else {
+      setOrderQuantity(orderQuantity - 1);
+    }
+  }
+  function plusOrderQuantity() {
+    setOrderQuantity(orderQuantity + 1);
+  }
+  function deleteProduct() {
+    alert('선택하신 상품을 삭제하시겠습니까?');
+    setCartModal(false);
+  }
+  return (
+    <div
+      key={cartData.id}
+      className="selected"
+      style={cartModal ? { display: 'flex' } : { display: 'none' }}
+    >
+      <div className="productInfo">
+        <img src={cartData.cart_img_url} alt="selected_tiny" />
+        <div className="description">
+          <div>{cartData.title}</div>
+          <div>₩{cartData.price},000</div>
+          <div className="count">
+            <img
+              onClick={minusOrderQuantity}
+              src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
+              alt="minus"
+            />
+            <span>{orderQuantity}</span>
+            <img
+              onClick={plusOrderQuantity}
+              src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
+              alt="plus"
+            />
+          </div>
+        </div>
+        <p onClick={deleteProduct} className="delete">
+          ×
+        </p>
+      </div>
+    </div>
+  );
+}
 
 export default Cart;

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -2,13 +2,51 @@ import React, { useState, useEffect } from 'react';
 import './Cart.scss';
 
 const Cart = () => {
-  const [orderQuantity, setOrderQuantity] = useState(0);
   const [cartData, setCartData] = useState([]);
+  const [orderQuantity, setOrderQuantity] = useState(1);
   const [cartModal, setCartModal] = useState(true);
+  const [total, setTotal] = useState(0);
+
+  // console.log(cartData);
+
+  const totalPrice = cartData[0]?.price.toString().slice(0, 2) * orderQuantity;
+  // console.log(totalPrice);
+
+  function changeTotal() {
+    setTotal(totalPrice);
+  }
+
+  function getCartDataPrice(cartData) {
+    let cartDataPrice = [];
+    for (let i = 0; i < cartData.length; i++) {
+      cartDataPrice.push(
+        cartData[i].price.toString().slice(0, 2) * orderQuantity
+      );
+    }
+    return cartDataPrice;
+  }
+  const priceThousand = getCartDataPrice(cartData);
+  console.log(priceThousand && priceThousand?.reduce((a, b) => a + b));
+
+  // function totalPrice() {
+
+  // }
 
   const closeCart = () => {
     setCartModal(false);
   };
+
+  function minusOrderQuantity() {
+    if (orderQuantity < 2) {
+      setOrderQuantity(1);
+    } else {
+      setOrderQuantity(orderQuantity => orderQuantity - 1);
+    }
+  }
+
+  function plusOrderQuantity() {
+    setOrderQuantity(orderQuantity => orderQuantity + 1);
+  }
 
   useEffect(() => {
     fetch('data/cartData.json')
@@ -22,50 +60,72 @@ const Cart = () => {
     <div
       className="cartModal"
       style={cartModal ? { visibility: 'visible' } : { visibility: 'hidden' }}
-      onClick={closeCart}
     >
       <div className="cartNav">
         <span>Cart[{orderQuantity}]</span>
-        <span>Close</span>
+        <span onClick={closeCart}>Close</span>
       </div>
       <div className="cartMain">
         {/* <div className="empty">
             <p>장바구니가 비어 있습니다.</p>
           </div> */}
 
-        {/* 여기 map 돌리면 됨 */}
         {cartData.map(cartData => {
-          return <SelectedPrd key={cartData.id} cartData={cartData} />;
+          return (
+            <SelectedPrd
+              key={cartData.id}
+              cartData={cartData}
+              minusOrderQuantity={minusOrderQuantity}
+              plusOrderQuantity={plusOrderQuantity}
+              changeTotal={changeTotal}
+            />
+          );
         })}
       </div>
       <div className="cartFooter">
         <span>
-          ₩{orderQuantity === 0 ? 15 : 15 * orderQuantity},000 VIEW ALL
+          ₩{total}
+          ,000 VIEW ALL
         </span>
       </div>
     </div>
   );
 };
-function SelectedPrd({ cartData }) {
-  const { cart_img_url, id, price, title } = cartData;
+function SelectedPrd({
+  cartData,
+  minusOrderQuantity,
+  plusOrderQuantity,
+  changeTotal,
+}) {
+  const [orderQuantity, setOrderQuantity] = useState(1);
+  const totalPrice = cartData.price * orderQuantity;
+  // console.log(totalPrice);
+  // console.log(cartData);
 
-  const [orderQuantity, setOrderQuantity] = useState(0);
+  const plus = () => {
+    setOrderQuantity(prev => prev + 1);
+    plusOrderQuantity();
 
-  const [selected, setSelected] = useState(true);
+    const totalPrice = cartData.price * orderQuantity;
+    changeTotal(cartData.price * orderQuantity);
+    // console.log(totalPrice);
+  };
 
-  const priceThousand = price.toString().slice(0, 2);
-
-  function minusOrderQuantity() {
+  const minus = e => {
+    // console.log(e.target);
     if (orderQuantity < 2) {
       setOrderQuantity(1);
     } else {
-      setOrderQuantity(orderQuantity - 1);
+      setOrderQuantity(prev => prev - 1);
     }
-  }
+    minusOrderQuantity();
+    changeTotal(totalPrice);
+  };
 
-  function plusOrderQuantity() {
-    setOrderQuantity(orderQuantity + 1);
-  }
+  const [selected, setSelected] = useState(true);
+
+  const priceThousand = cartData.price.toString().slice(0, 2);
+  // console.log(priceThousand);
 
   function deleteProduct() {
     alert('선택하신 상품을 삭제하시겠습니까?');
@@ -74,24 +134,24 @@ function SelectedPrd({ cartData }) {
 
   return (
     <div
-      key={id}
+      key={cartData.id}
       className="selected"
       style={selected ? { display: 'flex' } : { display: 'none' }}
     >
       <div className="productInfo">
-        <img src={cart_img_url} alt="selected_tiny" />
+        <img src={cartData.cart_img_url} alt="selected_tiny" />
         <div className="description">
-          <div>{title}</div>
+          <div>{cartData.title}</div>
           <div>₩{priceThousand},000</div>
           <div className="count">
             <img
-              onClick={minusOrderQuantity}
+              onClick={minus}
               src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
               alt="minus"
             />
             <span>{orderQuantity}</span>
             <img
-              onClick={plusOrderQuantity}
+              onClick={plus}
               src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
               alt="plus"
             />

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -1,50 +1,85 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import './Cart.scss';
 
 const Cart = () => {
-  // const [cartCount, setCartCount] = useState(0);
-
-  return (
-    <div className="cartModal">
-      <div className="cartNav">
-        <span>Cart[]</span>
-        <span>Close</span>
-      </div>
-      <div className="cartMain">
-        {/* <div className="empty">
-          <p>장바구니가 비어 있습니다.</p>
-        </div> */}
-        <div className="selected">
-          <div className="productInfo">
-            <img
-              src="https://images.unsplash.com/photo-1598745845211-7d7a22d8cc25?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=687&q=80"
-              alt="selected_tiny"
-            />
-            <div className="description">
-              <div>LE LABO</div>
-              <div>₩15,000</div>
-              <div className="count">
-                <img
-                  src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
-                  alt="minus"
-                />
-                <span>4</span>
-                <img
-                  src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
-                  alt="plus"
-                />
-              </div>
-            </div>
-            <p className="delete">×</p>
-          </div>
-        </div>
-      </div>
-      <a className="cartFooter">
-        <span>₩18,000 VIEW ALL</span>
-      </a>
-    </div>
-  );
+  //   const [orderQuantity, setOrderQuantity] = useState(0);
+  //   const [cartModal, setCartModal] = useState(true);
+  //   const [cartData, setCartData] = useState([]);
+  //   useEffect(() => {
+  //     fetch('data/cartData.json')
+  //       .then(res => res.json())
+  //       .then(data => {
+  //         setCartData(data);
+  //       });
+  //   }, []);
+  //   function minusOrderQuantity() {
+  //     if (orderQuantity < 2) {
+  //       setOrderQuantity(1);
+  //     } else {
+  //       setOrderQuantity(orderQuantity - 1);
+  //     }
+  //   }
+  //   function plusOrderQuantity() {
+  //     setOrderQuantity(orderQuantity + 1);
+  //   }
+  //   function deleteProduct() {
+  //     alert('선택하신 상품을 삭제하시겠습니까?');
+  //     setCartModal(false);
+  //   }
+  //   return (
+  //     <div className="cartModal">
+  //       <div className="cartNav">
+  //         <span>Cart[{orderQuantity}]</span>
+  //         <span>Close</span>
+  //       </div>
+  //       <div className="cartMain">
+  //         {/* <div className="empty">
+  //           <p>장바구니가 비어 있습니다.</p>
+  //         </div> */}
+  //         {/* 여기 map 돌리면 됨 */}
+  //         {cartData.map(cartData => {
+  //           return <SelectedPrd cartData={cartData} />;
+  //         })}
+  //       </div>
+  //       <a className="cartFooter">
+  //         <span>
+  //           ₩{orderQuantity === 0 ? 15 : 15 * orderQuantity},000 VIEW ALL
+  //         </span>
+  //       </a>
+  //     </div>
+  //   );
+  // };
+  // function SelectedPrd({ cartData }) {
+  //   <div
+  //     key={cartData.id}
+  //     className="selected"
+  //     style={cartModal ? { display: 'flex' } : { display: 'none' }}
+  //   >
+  //     <div className="productInfo">
+  //       <img src={cartData.cart_img_url} alt="selected_tiny" />
+  //       <div className="description">
+  //         <div>{cartData.title}</div>
+  //         <div>₩{cartData.price},000</div>
+  //         <div className="count">
+  //           <img
+  //             onClick={minusOrderQuantity}
+  //             src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
+  //             alt="minus"
+  //           />
+  //           <span>{orderQuantity}</span>
+  //           <img
+  //             onClick={plusOrderQuantity}
+  //             src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
+  //             alt="plus"
+  //           />
+  //         </div>
+  //       </div>
+  //       <p onClick={deleteProduct} className="delete">
+  //         ×
+  //       </p>
+  //     </div>
+  //   </div>;
 };
 
 export default Cart;

--- a/src/pages/Cart/Cart.scss
+++ b/src/pages/Cart/Cart.scss
@@ -17,10 +17,8 @@
     font-size: 1.25rem;
     font-weight: 500;
   }
-
   .cartMain {
     color: #fff;
-
     .empty {
       padding-top: 8.125rem;
       font-size: 1rem;
@@ -73,11 +71,9 @@
           right: -90px;
           
         }
-
       }
     }
   }
-
   .cartFooter {
     position: fixed;
     bottom: 0;
@@ -88,8 +84,6 @@
     font-size: 1.3rem;
     color: #fff;
     font-weight: 600;
+    background-color: #000;
   }
-
-
-
 }

--- a/src/pages/Cart/Cart.scss
+++ b/src/pages/Cart/Cart.scss
@@ -62,10 +62,12 @@
           }
         }
         p {
+          width: 24px;
           font-size: 1.5rem;
           line-height: 1;
           position: relative;
           right: -90px;
+          
         }
 
       }

--- a/src/pages/Cart/Cart.scss
+++ b/src/pages/Cart/Cart.scss
@@ -1,0 +1,89 @@
+.cartModal {
+  position: fixed;
+  right: 0;
+  width: 340px;
+  height: 100%;
+  background-color: #000;
+
+  .cartNav {
+    display: flex;
+    justify-content: space-between;
+    padding: 15px 20px;
+    color: #fff;
+    font-size: 1.25rem;
+    font-weight: 500;
+  }
+
+  .cartMain {
+    color: #fff;
+
+    .empty {
+      padding-top: 8.125rem;
+      font-size: 1rem;
+      text-align: center;
+    }
+    .selected {
+      .productInfo {
+        display: flex;
+        padding: 1rem 1.5rem;
+        img {
+          width: 80px;
+          height: 112px;
+        }
+        .description {
+          padding-left: 1rem;
+          color: #fff;
+          font-weight: 600;
+          line-height: 1.4;
+          
+          div:nth-child(2){
+            padding-bottom: 1rem;
+          }
+          .count {
+            font-size: 1.25rem;
+            border: 1px solid #fff;
+            display: flex;
+            justify-content: space-around;
+            line-height: 1.5;
+            width: 94px;
+            height: 32px;
+              img {
+                width: 20px;
+                height: 20px;
+                margin-top: 4px;
+                margin-bottom: 4px;
+                
+              }
+            
+            span{
+              margin-top: 1px;
+            }
+            
+          }
+        }
+        p {
+          font-size: 1.5rem;
+          line-height: 1;
+          position: relative;
+          right: -90px;
+        }
+
+      }
+    }
+  }
+
+  .cartFooter {
+    position: fixed;
+    bottom: 0;
+    width: 340px;
+    text-align: center;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
+    font-size: 1.3rem;
+    color: #fff;
+    font-weight: 600;
+  }
+
+
+
+}

--- a/src/pages/Cart/Cart.scss
+++ b/src/pages/Cart/Cart.scss
@@ -1,9 +1,13 @@
 .cartModal {
   position: fixed;
   right: 0;
+  display: flex;
+  flex-direction: column;
   width: 340px;
   height: 100%;
   background-color: #000;
+  transition: all 0.3s;
+
 
   .cartNav {
     display: flex;

--- a/src/pages/Cart/SelectedPrd.js
+++ b/src/pages/Cart/SelectedPrd.js
@@ -1,20 +1,8 @@
 import React, { useEffect } from 'react';
 import { useState } from 'react';
 
-const SelectedPrd = ({
-  cartData,
-  minusOrderQuantity,
-  plusOrderQuantity,
-  price,
-  setPrice,
-  idx,
-  deleteProduct,
-}) => {
+const SelectedPrd = ({ cartData, minusOrderQuantity, plusOrderQuantity }) => {
   const [orderQuantity, setOrderQuantity] = useState(1);
-
-  useEffect(() => {
-    setOrderQuantity(cartData.order);
-  }, []);
 
   const plus = () => {
     setOrderQuantity(prev => prev + 1);
@@ -30,19 +18,27 @@ const SelectedPrd = ({
     }
   };
 
-  price[idx] = cartData.price.toString().slice(0, 2) * orderQuantity;
+  const [selected, setSelected] = useState(true);
 
-  useEffect(() => {
-    setPrice(() => price);
-  }, [[price[idx]]]);
+  const priceThousand = cartData.price.toString().slice(0, 2);
+  // console.log(priceThousand);
+
+  function deleteProduct() {
+    alert('선택하신 상품을 삭제하시겠습니까?');
+    setSelected(false);
+  }
 
   return (
-    <div key={cartData.id} className="selected">
+    <div
+      key={cartData.id}
+      className="selected"
+      style={selected ? { display: 'flex' } : { display: 'none' }}
+    >
       <div className="productInfo">
         <img src={cartData.cart_img_url} alt="selected_tiny" />
         <div className="description">
           <div>{cartData.title}</div>
-          <div>₩{price[idx]},000</div>
+          <div>₩{priceThousand},000</div>
           <div className="count">
             <img
               onClick={minus}
@@ -57,12 +53,7 @@ const SelectedPrd = ({
             />
           </div>
         </div>
-        <p
-          onClick={() => {
-            deleteProduct(cartData.id, orderQuantity);
-          }}
-          className="delete"
-        >
+        <p onClick={deleteProduct} className="delete">
           ×
         </p>
       </div>

--- a/src/pages/Cart/SelectedPrd.js
+++ b/src/pages/Cart/SelectedPrd.js
@@ -1,0 +1,73 @@
+import React, { useEffect } from 'react';
+import { useState } from 'react';
+
+const SelectedPrd = ({
+  cartData,
+  minusOrderQuantity,
+  plusOrderQuantity,
+  price,
+  setPrice,
+  idx,
+  deleteProduct,
+}) => {
+  const [orderQuantity, setOrderQuantity] = useState(1);
+
+  useEffect(() => {
+    setOrderQuantity(cartData.order);
+  }, []);
+
+  const plus = () => {
+    setOrderQuantity(prev => prev + 1);
+    plusOrderQuantity();
+  };
+
+  const minus = e => {
+    if (orderQuantity < 2) {
+      setOrderQuantity(1);
+    } else {
+      setOrderQuantity(prev => prev - 1);
+      minusOrderQuantity();
+    }
+  };
+
+  price[idx] = cartData.price.toString().slice(0, 2) * orderQuantity;
+
+  useEffect(() => {
+    setPrice(() => price);
+  }, [[price[idx]]]);
+
+  return (
+    <div key={cartData.id} className="selected">
+      <div className="productInfo">
+        <img src={cartData.cart_img_url} alt="selected_tiny" />
+        <div className="description">
+          <div>{cartData.title}</div>
+          <div>₩{price[idx]},000</div>
+          <div className="count">
+            <img
+              onClick={minus}
+              src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_minus_white.png"
+              alt="minus"
+            />
+            <span>{orderQuantity}</span>
+            <img
+              onClick={plus}
+              src="https://magazine-b.co.kr/web/baton/images/icon/icon_product_plus_white.png"
+              alt="plus"
+            />
+          </div>
+        </div>
+        <p
+          onClick={() => {
+            deleteProduct(cartData.id, orderQuantity);
+          }}
+          className="delete"
+        >
+          ×
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default SelectedPrd;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

* 장바구니 총합 구현부터 원영님이 맡으셨습니다! 

## :: 구현 목표 
- navbar의 cart를 눌렀을 때와 상품 상세페이지에서 ADD TO CART버튼을 눌렀을 때
장바구니 모달 창이 생깁니다.

- 상품이 담겨있지 않을 때와 담겨있을 때의 레이아웃이 다릅니다.

- 상품의 총 개수가 cart[0] 괄호 안에 카운트됩니다.

- 장바구니 모달창 안에서 그리고 상세페이지에서 버튼을 누를때마다 개수가 카운트 되고
동시에 총 가격도 보여줍니다.

-  X버튼을 누르면 alert창이 뜨고 상품을 삭제하면 상품이 삭제된다.

- close버튼을 누르면 모달창이 꺼진다.



<br />

## :: 구현 사항 설명 

<br />

## :: 성장 포인트 



<br />

## :: 기타 질문 및 특이 사항


