### PR TITLE
[35기 주원영] 상품 리스트 페이지 / 스크롤업 기능, 카테고리 메뉴 포커스온 기능 추가

### DIFF
--- a/src/pages/ProductList/MenuTap.js
+++ b/src/pages/ProductList/MenuTap.js
@@ -1,11 +1,23 @@
 import './MenuTap.scss';
 
-const MenuTap = ({ menu, movePage }) => {
+const MenuTap = ({ menu, movePage, isClickedList, idx, scrollUp }) => {
+  const focusOnMenuTap = target => {
+    isClickedList.forEach((menu, i) => {
+      if (i !== target) {
+        isClickedList[i] = false;
+      } else {
+        isClickedList[i] = true;
+      }
+    });
+  };
+
   return (
     <div
-      className="menuTapOn"
+      className={isClickedList[idx] ? 'menuTapOn' : 'menuTapOff'}
       onClick={() => {
-        movePage(menu.category, 1, 0);
+        movePage(menu.category, 1);
+        focusOnMenuTap(idx);
+        scrollUp();
       }}
     >
       {menu.cate_name}

--- a/src/pages/ProductList/MenuTap.scss
+++ b/src/pages/ProductList/MenuTap.scss
@@ -11,6 +11,8 @@
 .menuTapOff {
   margin-bottom: 0.5rem;
   color: #cccccc;
+  transition: color 0.2s linear;
+
   &:hover {
     cursor: pointer;
   }

--- a/src/pages/ProductList/PageList.js
+++ b/src/pages/ProductList/PageList.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import './PageList.scss';
 
-const PageList = ({ total, limit, movePage, pgNext, pgPrev, category }) => {
+const PageList = ({
+  total,
+  limit,
+  movePage,
+  pgNext,
+  pgPrev,
+  category,
+  scrollUp,
+}) => {
   const pageNum = Math.ceil(total / limit);
 
   return (
@@ -25,6 +33,7 @@ const PageList = ({ total, limit, movePage, pgNext, pgPrev, category }) => {
               className="pageLink"
               onClick={() => {
                 movePage(category, idx + 1);
+                scrollUp();
               }}
             >
               {idx + 1}

--- a/src/pages/ProductList/PageList.scss
+++ b/src/pages/ProductList/PageList.scss
@@ -11,7 +11,7 @@
 }
 
 .pageLinkContainer {
-  @include flex(center, center, null);
+  @include flex(center, center);
   margin: 4rem 0;
   width: 100%;
   .pageLinkPrev {

--- a/src/pages/ProductList/Product.js
+++ b/src/pages/ProductList/Product.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import './Product.scss';
 
-const Product = ({ prod, category }) => {
+const Product = ({ prod }) => {
   const {
     main_category,
     main_img_url_1,
@@ -29,6 +29,7 @@ const Product = ({ prod, category }) => {
         },
         body: JSON.stringify({
           product: product_id,
+          count: 1,
         }),
       });
     } else {

--- a/src/pages/ProductList/Product.scss
+++ b/src/pages/ProductList/Product.scss
@@ -19,7 +19,7 @@
   }
 
   .prodInfoContainer {
-    @include flex(space-between, '', null);
+    @include flex(space-between);
     padding: 0.7rem 0.5rem 0.7rem 0.5rem;
     font-size: 1rem;
     font-weight: 500;

--- a/src/pages/ProductList/ProductList.js
+++ b/src/pages/ProductList/ProductList.js
@@ -14,6 +14,7 @@ const ProductList = () => {
   const [total, setTotal] = useState(0);
   const [limit, setLimit] = useState(10);
   const [sort, setSort] = useState(0);
+  const [isClickedList, setIsClickedList] = useState([]);
 
   const category = searchParams.get('category');
   const pageNum = Math.ceil(total / limit);
@@ -25,6 +26,13 @@ const ProductList = () => {
     setPage(() => page);
     offset = (page - 1) * limit;
     navigate(`?category=${category}`);
+  };
+
+  const scrollUp = () => {
+    window.scroll({
+      top: 0,
+      behavior: 'smooth',
+    });
   };
 
   useEffect(() => {
@@ -49,11 +57,22 @@ const ProductList = () => {
       });
   }, [category, offset, limit, sort]);
 
+  useEffect(() => {
+    setIsClickedList(Array(MENU_LIST.length).fill(true));
+  }, []);
+
   return (
     <div className="productListPage">
       <div className="menuTapContainer">
-        {MENU_LIST.map(menu => (
-          <MenuTap key={menu.category} menu={menu} movePage={movePage} />
+        {MENU_LIST.map((menu, idx) => (
+          <MenuTap
+            key={menu.category}
+            menu={menu}
+            movePage={movePage}
+            isClickedList={isClickedList}
+            idx={idx}
+            scrollUp={scrollUp}
+          />
         ))}
         <div className="prodNumPerPage">
           <span className="totalNum">TOTAL {total}</span>
@@ -63,6 +82,7 @@ const ProductList = () => {
               className="numPerPage"
               onChange={e => {
                 setLimit(e.target.value);
+                scrollUp();
               }}
               defaultValue="10"
             >
@@ -76,6 +96,7 @@ const ProductList = () => {
               className="sort"
               onChange={e => {
                 setSort(e.target.value);
+                scrollUp();
               }}
             >
               <option>SORT BY</option>
@@ -99,6 +120,7 @@ const ProductList = () => {
           pgPrev={pgPrev}
           category={category}
           limit={limit}
+          scrollUp={scrollUp}
         />
       </div>
     </div>

--- a/src/pages/ProductList/ProductList.scss
+++ b/src/pages/ProductList/ProductList.scss
@@ -1,8 +1,10 @@
 @import '../../styles/variables.scss';
 
 .productListPage {
-  @include flex(center, flex-start, null);
+  @include flex(center, flex-start);
   position: relative;
+  height: 100%;
+  margin-top: 6rem;
   padding: 0 3rem;
 
   .menuTapContainer {
@@ -10,21 +12,17 @@
     flex: 1;
     position: sticky;
     height: 98vh;
-    top: 1.1rem;
+    top: 7rem;
     margin: 1rem 0 0 0;
     font-size: 2.7rem;
     font-weight: 500;
 
     .prodNumPerPage {
       @include flex(space-between, center);
-      position: absolute;
-      bottom: 4rem;
+      margin-top: 30rem;
       width: 25rem;
       height: 2rem;
       font-size: 1rem;
-
-      .totalNum {
-      }
 
       .numPerPageWrapper {
         .numPerPage {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 상품 리스트 페이지 레이아웃 완성
- 카테고리 및 페이지수에 맞는 데이터 호출 후 리스트 업

<br />

## :: 구현 사항 설명
1. 상품 리스트 페이지 레이아웃 
- 기본적인 레이아웃 완료
- flex를 활용한 데이터 목록 레이아웃 배치
- map() 메소드를 통한 목데이터 리스트 업
- stickey position을 이용한 카테고리 탭 메뉴 고정

2. 쿼리파라미터를 카테고리별 데이터 호출 기능 구현
- 카테고리 메뉴 탭을 클릭하면, 해당하는 카테고리의 상품들이 화면에 렌더된다.
- 이때 원하는 상품들을 가져올 수 있도록 카테고리 메뉴 탭을 클릭하면 fetch함수가 동작하도록 구현했다.
- fetch함수는 url에 카테고리에 따른 변수를 부여 했는데 이 때 변수를 쿼리 파라미터로 구현했다.
- 즉, 카테고리 메뉴탭을 클릭하면 category number를 쿼리 파라미터로 받아오게 하고 이 값을 이용해 각각의 api에 호출하는 로직이다.

3. 페이지에 상품 5개씩 노출되는 기능, 페이지네이션 기능 구현
- 페이지에 상품이 5개만 노출될 수 있도록, 목데이터를 slice함수로 잘라서 map함수를 적용하였다.
- 페이지네이션 기능을 구현하기위해 목데이터가 아닌 임의의 배열을 생성하였다.
- `Array(page수)fill()`을 사용하면 빈 값으로 이루어진 배열이 페이지수의 길이로 생성된다. 
- 이 값을 map함수를 통해 페이지네이션을 구현하였다.


<br />

## :: 성장 포인트 
- 반복되는 ui에 대한 컴포넌트화, 필요한 값들을 props로 자식에게 넘겨주는 상황과 로직에 대한 이해
> 상품, 카테고리 메뉴를 컴포넌트화 하여 map 메소드를 통해 ui에 보여지게끔 로직을 완성하였다. 또한, 이에 필요한 값들을 props로 넘겨주었다.

- 목데이터가 왜 필요한지, API에서 어떤 데이터들을 받으며 key값들을 어떻게 할 지에 대한 고민.
> 상품 리스트 페이지를 구성하면서 화면에 보여지는 거의 모든 데이터들은 백엔드에서 가져와야 하며, 어떻게 어떤식으로 가져와서 어떻게 보여줘야할 지에 대한 고민을 많이할 수 있었다. 특히, 이전에 혼자 프로젝트를 진행할 떄 막연하게 생각했던 것 보다 훨씬 구체적으로 와닿을 수 있었던 경험이어서 유익했다. 앞으로 더 맞춰나가야하고 이해해야할 부분이 많다. 

- 카테고리 탭을 클릭하였을 때, 해당 카테고리에 해당하는 값만 데이터를 불러오기 위해서 백엔드와 어떻게 통신하고 정해야 할지에 대해 고민
> 카테고리 별 목데이터를 만들어, 카테고리 탭을 누르면 해당하는 데이터들이 호출되는 형식으로 먼저 구현하였다. 그러나, 매거진B 홈페이지를 살펴보니 카테고리나 페이지를 누르면 url의 ?뒤에 cate_num와 pg가 변하는 로직을 발견하였고 이는 라우터 돔의 쿼리스트링 기능이라는 것을 알게되었음. 현재 url에 해당하는 쿼리스트링 값을 노출시키고 그 값을 사용하는 것 까지는 이해하였음.

- 특정 개수의 상품만 화면에 보여지게 하는 기능과 더불어 페이지네이션에 대한 고민
> 처음엔 모든 데이터리스트를 받고 그 데이터들을 프론트 단에서 가공하고 보여주는 것으로 생각했으나, 사이트 규모가 커질수록 무거운 과정이기 때문에 특정 카테고리와 페이지수에 해당하는 데이터만 백엔드에 요청하는 로직으로 해야겠다고 생각했다. 

- Query parameters를 이용한 카테고리별 데이터 호출 기능 구현
> 카테고리 별로 데이터를 요청하기 위해서 fetch함수의 링크에 변수를 줘야한다. 그 변수를 상품리스트의 Query parameters으로 할당하면 적합하다고 판단했다. 쿼리 파라미터를 사용하기 위해 useSearchParams를 이용했고, 쿼리스트링값(카테고리넘버)를 useEffect안의 fetch함수 url값에 넣었다. 이때 useEffect는 카테고리가 바뀔때마다 상품 리스트를 새로 가져와야 하므로, 쿼리스트링 값에 변화가 생기면 동작하도록 구현했다.
> 카테고리 메뉴 탭을 클릭하면 url의 쿼리파리미터(카테고리넘버)가 변경되고 그 변경된 값에 맞는 데이터를 fetch함수를 통해 가져와 ui에 렌더시킨다.

- 상품의 특정 개수만 페이지에 렌더시키는 기능 구현
> map함수를 통해 카테고리 별 데이터를 렌더시켰지만, 5개씩 상품이 보여지게 하도록 구현해야했다. map 함수를 통해 목데이터(배열)의 모든 값을 가져오지 않고 5개만 가져오기 위해, slice메서드를 사용했다. 
> 페이지에 노출할 상품의 개수(limit), 목데이터 slice 시작 위치(offset), 현재 페이지(page)로 각각 변수 혹은 state값으로 부여하였고,         `prodList.slice(offset, limit * page).map((prod) => {중략})`로 5개씩 화면에 렌더시킬 수 있었다.

- 페이지네이션 기능 구현
> 5개씩 상품이 보여지게 구현을 한 후, 상품 리스트 하단에 페이지네이션을 추가하여 다음 페이지로 넘어가는 기능을 구현하려 했다. 이때 페이지의 경우에는 상품 리스트처럼 맵함수를 사용하기 어렵다고 생각했다(페이지는 배열의 형태가 아니라고 생각해서) 그러나, Array(number)의 메소드를 사용하면 number만큼 배열의 길이를 만들수 있다는 것을 깨닫고 `Array(pageNum).fill().map((el, idx)` 이와 같이 페이지네이션을 구현할 수 있었다. pageNum은 페이지 수(리스트가 12개인 경우 5개씩 보여주면 3)이고 Array(pageNum)을 통해 길이가 3인 배열을 만들고 fill()메서드를 통해 값을 undefined로 넣어주며, 이 배열에 map함수를 돌려 페이지 수 만큼의 버튼 태그를 생성하였다. 

- 목데이터가 아닌 백엔드 API로부터 데이터를 가져와서 상품리스트를 렌더시키는 기능 구현
>  목데이터를 프론트 단에서 가공하여 ui에 상품리스트를 보여줬었는데, 실제로 백엔드로부터 데이터를 받아서 보여주는 과정에서 많은 착오가 발생했다. 첫째로는 데이터가 배열자체로 오는 것이 아니라 response라는 객체안에 result라는 키값에 접근해야 배열에 접근할 수 있었다. 두번째는 백엔드의 상품리스트 데이터가 몇개인지 정보를 받아야 페이지네이션이 가능했으므로, 토탈개수 값을 요청하였다. 그 결과 데이터를 가져와서 가공하는 과정이 필요했다. (상품총개수 데이터를 제외한 나머지 상품정보만 productList state에 추가) 

<br />

## :: 기타 질문 및 특이 사항
- 